### PR TITLE
Adding STASH_IS_DRY_RUN environment variable to merge-check hook

### DIFF
--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalMergeCheckHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalMergeCheckHook.java
@@ -91,6 +91,7 @@ public class ExternalMergeCheckHook
 
         // Using the same env variables as
         // https://github.com/tomasbjerre/pull-request-notifier-for-bitbucket
+        env.put("STASH_IS_DRY_RUN", context.getMergeRequest().isDryRun() ? "1" : "0");
         env.put("PULL_REQUEST_FROM_HASH", pr.getFromRef().getLatestCommit());
         env.put("PULL_REQUEST_FROM_ID", pr.getFromRef().getId());
         env.put("PULL_REQUEST_FROM_BRANCH", pr.getFromRef().getDisplayId());


### PR DESCRIPTION
This environment variable will allow the merge-check hook to know if the user really clicked the Merge button or just opened the pull-request screen and Bitbucket wants to know if it should enable the Merge button.