### PR TITLE
Restore BitBucket 4 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.ngs.stash.externalhooks</groupId>
     <artifactId>external-hooks</artifactId>
-    <version>3.3-3-SNAPSHOT</version>
+    <version>3.3-2</version>
     <organization>
         <name>NGS</name>
         <url>http://ngs.ru/</url>
@@ -84,7 +84,7 @@
     </build>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <bitbucket.version>5.0.1</bitbucket.version>
+        <bitbucket.version>4.4.0</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
         <atlassian-sal-api.version>3.0.5</atlassian-sal-api.version>
         <slf4j.version>1.7.12</slf4j.version>

--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalAsyncPostReceiveHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalAsyncPostReceiveHook.java
@@ -2,6 +2,7 @@ package com.ngs.stash.externalhooks.hook;
 
 import com.atlassian.bitbucket.hook.repository.*;
 import com.atlassian.bitbucket.repository.*;
+import com.atlassian.bitbucket.scm.ScmService;
 import com.atlassian.bitbucket.setting.*;
 import com.atlassian.bitbucket.user.*;
 import com.atlassian.bitbucket.auth.*;
@@ -23,17 +24,20 @@ public class ExternalAsyncPostReceiveHook
     private PermissionService permissions;
     private RepositoryService repoService;
     private ApplicationPropertiesService properties;
+    private ScmService scmService;
 
     public ExternalAsyncPostReceiveHook(
         AuthenticationContext authenticationContext,
         PermissionService permissions,
         RepositoryService repoService,
-        ApplicationPropertiesService properties
+        ApplicationPropertiesService properties,
+        ScmService scmService
     ) {
         this.authCtx = authenticationContext;
         this.permissions = permissions;
         this.repoService = repoService;
         this.properties = properties;
+        this.scmService = scmService;
     }
 
     @Override
@@ -42,7 +46,7 @@ public class ExternalAsyncPostReceiveHook
         Collection<RefChange> refChanges
     ) {
         ExternalPreReceiveHook impl = new ExternalPreReceiveHook(
-            this.authCtx, this.permissions, this.repoService, this.properties);
+            this.authCtx, this.permissions, this.repoService, this.properties, this.scmService);
         impl.onReceive(context, refChanges, null);
     }
 
@@ -53,7 +57,7 @@ public class ExternalAsyncPostReceiveHook
         Repository repository
     ) {
         ExternalPreReceiveHook impl = new ExternalPreReceiveHook(this.authCtx,
-            this.permissions, this.repoService, this.properties);
+            this.permissions, this.repoService, this.properties, this.scmService);
         impl.validate(settings, errors, repository);
     }
 }

--- a/src/main/java/com/ngs/stash/externalhooks/hook/ExternalMergeCheckHook.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/ExternalMergeCheckHook.java
@@ -3,6 +3,7 @@ package com.ngs.stash.externalhooks.hook;
 import com.atlassian.bitbucket.hook.*;
 import com.atlassian.bitbucket.hook.repository.*;
 import com.atlassian.bitbucket.repository.*;
+import com.atlassian.bitbucket.scm.ScmService;
 import com.atlassian.bitbucket.setting.*;
 import com.atlassian.bitbucket.user.*;
 import com.atlassian.bitbucket.auth.*;
@@ -46,17 +47,20 @@ public class ExternalMergeCheckHook
     private PermissionService permissions;
     private RepositoryService repoService;
     private ApplicationPropertiesService properties;
+    private ScmService scmService;
 
     public ExternalMergeCheckHook(
         AuthenticationContext authenticationContext,
         PermissionService permissions,
         RepositoryService repoService,
-        ApplicationPropertiesService properties
+        ApplicationPropertiesService properties,
+        ScmService scmService
     ) {
         this.authCtx = authenticationContext;
         this.permissions = permissions;
         this.repoService = repoService;
         this.properties = properties;
+        this.scmService = scmService;
     }
 
     /**
@@ -159,7 +163,7 @@ public class ExternalMergeCheckHook
         Repository repo, String repoPath, List<String> exe, Settings settings
     ) {
         ExternalPreReceiveHook impl = new ExternalPreReceiveHook(this.authCtx,
-            this.permissions, this.repoService, this.properties);
+            this.permissions, this.repoService, this.properties, this.scmService);
         return impl.createProcessBuilder(repo, repoPath, exe, settings);
     }
 
@@ -169,7 +173,7 @@ public class ExternalMergeCheckHook
         HookResponse hookResponse
     ) throws InterruptedException, IOException {
         ExternalPreReceiveHook impl = new ExternalPreReceiveHook(this.authCtx,
-            this.permissions, this.repoService, this.properties);
+            this.permissions, this.repoService, this.properties, this.scmService);
         return impl.runExternalHooks(pb, refChanges, hookResponse);
     }
 
@@ -180,7 +184,7 @@ public class ExternalMergeCheckHook
         Repository repository
     ) {
         ExternalPreReceiveHook impl = new ExternalPreReceiveHook(this.authCtx,
-            this.permissions, this.repoService, this.properties);
+            this.permissions, this.repoService, this.properties, this.scmService);
         impl.validate(settings, errors, repository);
     }
 

--- a/src/main/java/com/ngs/stash/externalhooks/hook/helpers/ExternalRefChange.java
+++ b/src/main/java/com/ngs/stash/externalhooks/hook/helpers/ExternalRefChange.java
@@ -27,6 +27,12 @@ public class ExternalRefChange implements RefChange {
 
     @Nonnull
     @Override
+    public String getRefId() {
+        return ref.getId();
+    }
+
+    @Nonnull
+    @Override
     public String getFromHash() {
         return fromHash;
     }

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -23,6 +23,7 @@
   <component-import key="applicationProperties" interface="com.atlassian.sal.api.ApplicationProperties"/>
   <component-import key="authenticationContext" interface="com.atlassian.bitbucket.auth.AuthenticationContext" />
   <component-import key="permissions" interface="com.atlassian.bitbucket.permission.PermissionService" />
+  <component-import key="scmService" interface="com.atlassian.bitbucket.scm.ScmService" />
   <repository-hook name="External Pre Receive Hook" i18n-name-key="external-pre-receive-hook.name" key="external-pre-receive-hook" class="com.ngs.stash.externalhooks.hook.ExternalPreReceiveHook">
     <description key="external-pre-receive-hook.description">The External Pre Receive Hook Plugin</description>
     <icon>icon-example.png</icon>


### PR DESCRIPTION
We need to use a recent (2.11+) git with an older version of bitbucket.

As per [this comment](https://github.com/ngsru/atlassian-external-hooks/issues/50#issuecomment-307980142) I've created the following patch.

Tested in BitBucket Server 4.14.5.

**However, I'm not sure of ther versioning.**

Given the version and compatibility matrix [here](https://marketplace.atlassian.com/plugins/com.ngs.stash.externalhooks.external-hooks/versions), I've chosen `3.3-2`.

Would you be able to merge this, perhaps as a separate branch/tag, and upload to the marketplace?

Thank you!